### PR TITLE
OIDC bug fixes

### DIFF
--- a/src/aduneoclientfedid/Configuration.py
+++ b/src/aduneoclientfedid/Configuration.py
@@ -430,9 +430,9 @@ class ConfCrypto():
           else:
             self.modification = True
         elif key == 'token_endpoint_auth_method':
-          # Conversion de valeur de février 2024 - modifiée le 28 février 2025
-          if value in ['Basic', 'POST', 'client_secret_basic', 'client_secret_post']:
-            data[key] = {'Basic': 'basic', 'POST': 'form', 'client_secret_basic': 'basic', 'client_secret_post': 'form'}[value]
+          # Conversion de valeur de février 2024 - modifiée le 28 février 2025 - corrigée le 28 mai 2025
+          if value in ['basic', 'Basic', 'POST', 'client_secret_basic', 'client_secret_post']:
+            data[key] = {'Basic': 'client_secret_basic', 'basic': 'client_secret_basic', 'POST': 'client_secret_post', 'client_secret_basic': 'client_secret_basic', 'client_secret_post': 'client_secret_post'}[value]
             self.modification = True
         else:
           self.decrypt_json(value)

--- a/src/aduneoclientfedid/WebModules/OIDCClientLogin.py
+++ b/src/aduneoclientfedid/WebModules/OIDCClientLogin.py
@@ -556,7 +556,7 @@ class OIDCClientLogin(FlowHandler):
         self.log_error(('  ' * 1)+"Expiration verification failed:")
         self.log_error(('  ' * 2)+"Token issuer   : "+token_issuer)
         self.log_error(('  ' * 2)+"Metadata issuer: "+oidc_idp_params['issuer'])
-        self.add_result_row('Issuer verification', "Failed\n  token issuer: "+token_issuer+"\n  metadata issuer:"+meta_data['issuer'], 'issuer_verification')
+        self.add_result_row('Issuer verification', "Failed\n  token issuer: "+token_issuer+"\n  metadata issuer:"+oidc_idp_params['issuer'], 'issuer_verification')
         raise AduneoError('token issuer verification failed')
       
       # On vérifie l'audience du jeton, qui doit être le client ID


### PR DESCRIPTION
authentication method was saved as basic instead if client_secret_basic
Userinfo URL was blank because it was retrieved from the older Context